### PR TITLE
Empty message for EcdsaKoblitz signatures

### DIFF
--- a/js/jsonld-signatures.js
+++ b/js/jsonld-signatures.js
@@ -782,7 +782,7 @@ function _getDataToHash(input, options) {
     if(options.domain !== null && options.domain !== undefined) {
       toHash += '@' + options.domain;
     }
-  } else if(options.algorithm === 'LinkedDataSignature2015') {
+  } else if(options.algorithm === 'LinkedDataSignature2015' || options.algorithm === 'EcdsaKoblitzSignature2016') {
     var headers = {
       'http://purl.org/dc/elements/1.1/created': options.date,
       'https://w3id.org/security#domain': options.domain,


### PR DESCRIPTION
I noticed an issue with a EcdsaKoblitzSignature2016 codepath. `_getDataToHash` returns an empty string if options.algorithm is EcdsaKoblitzSignature2016. That means it's currently signing (and verifying) the empty message.

A better fix than this temporary workaround is to add a canonicalizationAlgorithm option (in addition to algorithm). In this case, the expected canonicalization algorithm is LinkedDataSignature2015, so I just added a check for that.